### PR TITLE
feat: prefer objects over classes for better type support

### DIFF
--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -16,6 +16,7 @@ export default class Bot {
     constructor(private readonly options: IBotOptions) {}
 
     public async start(): Promise<void> {
+        // Register plugins for dayjs (https://day.js.org/docs/en/plugin/loading-into-nodejs)
         dayjs.extend(duration);
         dayjs.extend(relativeTime);
         dayjs.extend(customParseFormat);

--- a/src/interactions/test/test.button.ts
+++ b/src/interactions/test/test.button.ts
@@ -2,14 +2,19 @@ import { IButton, IInteractionContext } from '../../types/bot-core';
 import { ButtonInteraction } from 'discord.js';
 import InteractionUtils from '../../utilities/interaction.util';
 
-export default class TestButton implements IButton {
-    public id = 'test_modal_btn';
+const TestButton: IButton = {
+    // The custom_id of the button that this interaction will be executed for
+    id: 'test_modal_btn',
 
-    public options = {
+    // Options for this interaction
+    options: {
         ephemeral: true,
-    };
+    },
 
-    public async execute({ interaction }: IInteractionContext<ButtonInteraction>): Promise<void> {
+    // The function that will be executed when the button is clicked
+    async execute({ interaction }: IInteractionContext<ButtonInteraction>): Promise<void> {
         await InteractionUtils.followUp(interaction, 'Button clicked!');
-    }
-}
+    },
+};
+
+export default TestButton;

--- a/src/interactions/test/test.command.ts
+++ b/src/interactions/test/test.command.ts
@@ -8,10 +8,12 @@ import {
 } from 'discord.js';
 import { ModalBuilder, TextInputBuilder } from '@discordjs/builders';
 
-export default class TestCommand implements ICommand {
-    public builder = new SlashCommandBuilder().setName('test').setDescription('Opens a modal.');
+const TestCommand: ICommand = {
+    // The builder that will be used to register the command
+    builder: new SlashCommandBuilder().setName('test').setDescription('Opens a modal.'),
 
-    public async execute({ interaction }: IInteractionContext<ChatInputCommandInteraction>): Promise<void> {
+    // The function that will be executed when the command is used
+    async execute({ interaction }: IInteractionContext<ChatInputCommandInteraction>): Promise<void> {
         // Create a new modal
         const modal = new ModalBuilder({
             title: 'Test Modal',
@@ -35,5 +37,7 @@ export default class TestCommand implements ICommand {
 
         // Send the modal to the user
         await interaction.showModal(modal);
-    }
-}
+    },
+};
+
+export default TestCommand;

--- a/src/interactions/test/test.modal.ts
+++ b/src/interactions/test/test.modal.ts
@@ -2,14 +2,17 @@ import { IModal, IInteractionContext, IInteractionOptions } from '../../types/bo
 import { ModalSubmitInteraction, ButtonBuilder, ButtonStyle, ActionRowBuilder } from 'discord.js';
 import InteractionUtils from '../../utilities/interaction.util';
 
-export default class TestModal implements IModal {
-    public id = 'test_modal';
+const TestModal: IModal = {
+    // The custom_id of the modal that this interaction will be executed for
+    id: 'test_modal',
 
-    public options: IInteractionOptions = {
+    // Options for this interaction
+    options: {
         ephemeral: true,
-    };
+    },
 
-    public async execute({ interaction }: IInteractionContext<ModalSubmitInteraction>): Promise<void> {
+    // The function that will be executed when the modal is submitted
+    async execute({ interaction }: IInteractionContext<ModalSubmitInteraction>): Promise<void> {
         // Create a new button
         const btn = new ButtonBuilder({
             custom_id: 'test_modal_btn',
@@ -21,5 +24,7 @@ export default class TestModal implements IModal {
 
         // Respond to the modal submit with a message containing a button
         await InteractionUtils.followUp(interaction, { content: 'Modal submitted!', components: [row] });
-    }
-}
+    },
+};
+
+export default TestModal;


### PR DESCRIPTION
Encountered an issue where `IInteractionOptions` weren't giving proper code suggestions in another project that uses this template.

The problem was fixed after switching to objects so I'm porting the fix to this repo as well.